### PR TITLE
fix: switched to the v3 method for requesting order data 

### DIFF
--- a/src/DTO/DellinTrack.php
+++ b/src/DTO/DellinTrack.php
@@ -47,6 +47,7 @@ class DellinTrack extends DataTransferObject
         if (is_array($data)) {
             $data = reset($data);
         }
+        error_log(print_r($data, true));
         $derivalDate = null;
         $arrivalDate = null;
         $orderId  = $data['orderId'] ?? null;

--- a/src/DTO/DellinTrack.php
+++ b/src/DTO/DellinTrack.php
@@ -69,7 +69,7 @@ class DellinTrack extends DataTransferObject
 
         return new self(
             [
-                'status'      => $data['state_name'] ?? null,
+                'status'      => $data['stateName'] ?? null,
                 'price'       => (float) $price,
                 'link'        => $link,
                 'startDate'   => $derivalDate,

--- a/src/DTO/DellinTrack.php
+++ b/src/DTO/DellinTrack.php
@@ -66,7 +66,7 @@ class DellinTrack extends DataTransferObject
         }
 
         if (isset($data['orderDates']['giveoutFromOspReceiver'])) {
-            $derivalDate = Carbon::parse($data['orderDates']['giveoutFromOspReceiver']);
+            $arrivalDate = Carbon::parse($data['orderDates']['giveoutFromOspReceiver']);
         } elseif (isset($data['orderDates']['arrivalToOspReceiver'])) {
             $arrivalDate = Carbon::parse($data['orderDates']['arrivalToOspReceiver']);
         }

--- a/src/DTO/DellinTrack.php
+++ b/src/DTO/DellinTrack.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace SergeevPasha\Dellin\DTO;
 
 use Carbon\Carbon;
-use Illuminate\Support\Facades\Log;
 use Spatie\DataTransferObject\DataTransferObject;
 
 class DellinTrack extends DataTransferObject
@@ -45,12 +44,7 @@ class DellinTrack extends DataTransferObject
      */
     public static function fromArray(array $data): self
     {
-        Log::info('Input data: ' . print_r($data, true));
-
-
         $data = $data['orders'][0];
-
-        Log::info(print_r($data, true));
         $derivalDate = null;
         $arrivalDate = null;
         $orderId  = $data['orderId'] ?? null;

--- a/src/DTO/DellinTrack.php
+++ b/src/DTO/DellinTrack.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace SergeevPasha\Dellin\DTO;
 
 use Carbon\Carbon;
+use Illuminate\Support\Facades\Log;
 use Spatie\DataTransferObject\DataTransferObject;
 
 class DellinTrack extends DataTransferObject

--- a/src/DTO/DellinTrack.php
+++ b/src/DTO/DellinTrack.php
@@ -44,10 +44,12 @@ class DellinTrack extends DataTransferObject
      */
     public static function fromArray(array $data): self
     {
+        Log::info('Input data: ' . print_r($data, true));
+
         if (is_array($data)) {
             $data = reset($data);
         }
-        error_log(print_r($data, true));
+        Log::info(print_r($data, true));
         $derivalDate = null;
         $arrivalDate = null;
         $orderId  = $data['orderId'] ?? null;

--- a/src/DTO/DellinTrack.php
+++ b/src/DTO/DellinTrack.php
@@ -47,9 +47,9 @@ class DellinTrack extends DataTransferObject
     {
         Log::info('Input data: ' . print_r($data, true));
 
-        if (is_array($data)) {
-            $data = reset($data);
-        }
+
+//        $data = reset($data);
+
         Log::info(print_r($data, true));
         $derivalDate = null;
         $arrivalDate = null;

--- a/src/DTO/DellinTrack.php
+++ b/src/DTO/DellinTrack.php
@@ -44,30 +44,33 @@ class DellinTrack extends DataTransferObject
      */
     public static function fromArray(array $data): self
     {
+        if (is_array($data)) {
+            $data = reset($data);
+        }
         $price       = 0;
         $derivalDate = null;
         $arrivalDate = null;
-        $orderId  = $data['order_id'] ?? null;
+        $orderId  = $data['orderId'] ?? null;
 
         if (isset($data['documents'])) {
-            $index = array_search('shipping', array_column($data['documents'], 'document_type'));
+            $index = array_search('shipping', array_column($data['documents'], 'documentType'));
             if ($index !== false) {
-                $price = $data['documents'][$index]['total_sum'] ?? 0;
+                $price = $data['documents'][$index]['totalSum'] ?? 0;
             }
         }
 
         $link = $orderId ? 'https://www.dellin.ru/tracker/orders/' . $orderId . '/' : '';
 
-        if (isset($data['ordered_at'])) {
-            $derivalDate = Carbon::parse($data['ordered_at']);
-        } elseif (isset($data['order_dates']['derrival_from_osp_sender'])) {
-            $derivalDate = Carbon::parse($data['order_dates']['derrival_from_osp_sender']);
+        if (isset($data['orderedAt'])) {
+            $derivalDate = Carbon::parse($data['orderedAt']);
+        } elseif (isset($data['orderDates']['derrivalFromOspSender'])) {
+            $derivalDate = Carbon::parse($data['orderDates']['derrivalFromOspSender']);
         }
 
-        if (isset($data['arrival_date'])) {
-            $arrivalDate = Carbon::parse($data['arrival_date']);
-        } elseif (isset($data['order_dates']['arrival_to_osp_receiver'])) {
-            $arrivalDate = Carbon::parse($data['order_dates']['arrival_to_osp_receiver']);
+        if (isset($data['arrivalDate'])) {
+            $arrivalDate = Carbon::parse($data['arrivalDate']);
+        } elseif (isset($data['orderDates']['arrivalToOspReceiver'])) {
+            $arrivalDate = Carbon::parse($data['orderDates']['arrivalToOspReceiver']);
         }
 
         return new self(

--- a/src/DTO/DellinTrack.php
+++ b/src/DTO/DellinTrack.php
@@ -47,28 +47,22 @@ class DellinTrack extends DataTransferObject
         if (is_array($data)) {
             $data = reset($data);
         }
-        $price       = 0;
         $derivalDate = null;
         $arrivalDate = null;
         $orderId  = $data['orderId'] ?? null;
+        $price = $data['totalSum'] ?? 0;
 
-        if (isset($data['documents'])) {
-            $index = array_search('shipping', array_column($data['documents'], 'documentType'));
-            if ($index !== false) {
-                $price = $data['documents'][$index]['totalSum'] ?? 0;
-            }
-        }
 
         $link = $orderId ? 'https://www.dellin.ru/tracker/orders/' . $orderId . '/' : '';
 
-        if (isset($data['orderedAt'])) {
-            $derivalDate = Carbon::parse($data['orderedAt']);
+        if (isset($data['orderDate'])) {
+            $derivalDate = Carbon::parse($data['orderDate']);
         } elseif (isset($data['orderDates']['derrivalFromOspSender'])) {
             $derivalDate = Carbon::parse($data['orderDates']['derrivalFromOspSender']);
         }
 
-        if (isset($data['arrivalDate'])) {
-            $arrivalDate = Carbon::parse($data['arrivalDate']);
+        if (isset($data['orderDates']['giveoutFromOspReceiver'])) {
+            $derivalDate = Carbon::parse($data['orderDates']['giveoutFromOspReceiver']);
         } elseif (isset($data['orderDates']['arrivalToOspReceiver'])) {
             $arrivalDate = Carbon::parse($data['orderDates']['arrivalToOspReceiver']);
         }

--- a/src/DTO/DellinTrack.php
+++ b/src/DTO/DellinTrack.php
@@ -61,8 +61,8 @@ class DellinTrack extends DataTransferObject
 
         if (isset($data['orderDate'])) {
             $derivalDate = Carbon::parse($data['orderDate']);
-        } elseif (isset($data['orderDates']['derrivalFromOspSender'])) {
-            $derivalDate = Carbon::parse($data['orderDates']['derrivalFromOspSender']);
+        } elseif (isset($data['orderDates']['derivalFromOspSender'])) {
+            $derivalDate = Carbon::parse($data['orderDates']['derivalFromOspSender']);
         }
 
         if (isset($data['orderDates']['giveoutFromOspReceiver'])) {

--- a/src/DTO/DellinTrack.php
+++ b/src/DTO/DellinTrack.php
@@ -48,7 +48,7 @@ class DellinTrack extends DataTransferObject
         Log::info('Input data: ' . print_r($data, true));
 
 
-        $data = $data[0];
+        $data = $data['orders'][0];
 
         Log::info(print_r($data, true));
         $derivalDate = null;

--- a/src/DTO/DellinTrack.php
+++ b/src/DTO/DellinTrack.php
@@ -48,7 +48,7 @@ class DellinTrack extends DataTransferObject
         Log::info('Input data: ' . print_r($data, true));
 
 
-//        $data = reset($data);
+        $data = $data[0];
 
         Log::info(print_r($data, true));
         $derivalDate = null;

--- a/src/Libraries/DellinClient.php
+++ b/src/Libraries/DellinClient.php
@@ -96,7 +96,7 @@ class DellinClient
     public function findByTrackNumber(string $trackNumber): DellinTrack
     {
         $data = $this->request(
-            '/v3/orders.json',
+            'v3/orders',
             [
                 'docIds' => [$trackNumber],
             ]

--- a/src/Libraries/DellinClient.php
+++ b/src/Libraries/DellinClient.php
@@ -96,9 +96,9 @@ class DellinClient
     public function findByTrackNumber(string $trackNumber): DellinTrack
     {
         $data = $this->request(
-            'v2/public/tracker',
+            '/v3/orders.json',
             [
-                'docid' => $trackNumber,
+                'docIds' => [$trackNumber],
             ]
         );
 


### PR DESCRIPTION
Switched to the v3 method for requesting order data due to the fact that v2 is archived and works with errors
The API now does not always return the correct delivery completion date in the archived version of the method, so it has been replaced with the current one
Does not change the structure of responses, should not break projects using this module

