### PR TITLE
fix: startDate

### DIFF
--- a/src/DTO/DellinTrack.php
+++ b/src/DTO/DellinTrack.php
@@ -71,9 +71,7 @@ class DellinTrack extends DataTransferObject
 
         $link = $orderId ? 'https://www.dellin.ru/tracker/orders/' . $orderId . '/' : '';
 
-        if (isset($data['orderDate'])) {
-            $derivalDate = Carbon::parse($data['orderDate']);
-        } elseif (isset($data['orderDates']['derivalFromOspSender'])) {
+        if (isset($data['orderDates']['derivalFromOspSender'])) {
             $derivalDate = Carbon::parse($data['orderDates']['derivalFromOspSender']);
         }
 


### PR DESCRIPTION
To avoid confusion, the StartDate is now determined only by the date it was sent from the sending terminal. There is a sending terminal in any order, this date must always be in the response. You can bind the "in transit" status to this date.